### PR TITLE
fix: ccmath use lxml.html to parse html

### DIFF
--- a/llm_web_kit/pipeline/extractor/html/recognizer/cc_math/tag_math.py
+++ b/llm_web_kit/pipeline/extractor/html/recognizer/cc_math/tag_math.py
@@ -1,7 +1,7 @@
 import re
 from copy import deepcopy
 
-from lxml import etree
+from lxml.html import HtmlElement
 
 from llm_web_kit.libs.html_utils import build_cc_element, element_to_html
 from llm_web_kit.libs.logger import logger
@@ -10,43 +10,37 @@ from llm_web_kit.pipeline.extractor.html.recognizer.cc_math.common import (
     EQUATION_INTERLINE, MathType, text_strip, wrap_math)
 
 
-def modify_tree(cm: CCMATH, math_render: str, o_html: str, node: etree._Element, parent: etree._Element):
+def modify_tree(cm: CCMATH, math_render: str, o_html: str, node: HtmlElement, parent: HtmlElement):
     try:
         annotation_tags = node.xpath('.//annotation[@encoding="application/x-tex"]')
+        math_type = MathType.MATHML
+        equation_type, math_type = cm.get_equation_type(o_html)
+        if equation_type == EQUATION_INLINE:
+            new_tag = CCMATH_INLINE
+        elif equation_type == EQUATION_INTERLINE:
+            new_tag = CCMATH_INTERLINE
+        else:
+            raise ValueError(f'Unknown equation type: {equation_type}')
 
         if len(annotation_tags) > 0:
             annotation_tag = annotation_tags[0]
             text = annotation_tag.text
-            new_tag = CCMATH_INTERLINE  # TODO: 需要判断，先认为mathML都是interline
-            contains_math, math_type = cm.contains_math(text)
-            if contains_math:
-                wrapped_text = wrap_math(text, display=True)
-                style_value = parent.get('style')
-                if style_value:
-                    normalized_style_value = style_value.lower().strip().replace(' ', '').replace(';', '')
-                    if 'display: none' in normalized_style_value:
-                        parent.style = ''
-                new_span = build_cc_element(html_tag_name=new_tag, text=wrapped_text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
-                parent.replace(node, new_span)
+            wrapped_text = wrap_math(text, display=True)
+            style_value = parent.get('style')
+            if style_value:
+                normalized_style_value = style_value.lower().strip().replace(' ', '').replace(';', '')
+                if 'display: none' in normalized_style_value:
+                    parent.style = ''
+            new_span = build_cc_element(html_tag_name=new_tag, text=wrapped_text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
+            parent.replace(node, new_span)
         elif text_strip(node.get('alttext')):
             # Get the alttext attribute
             alttext = node.get('alttext')
-            new_tag = CCMATH_INTERLINE  # TODO: 需要判断，先认为mathML都是interline
             if text_strip(alttext):
-                contains_math, math_type = cm.contains_math(text)
-                if contains_math:
-                    wrapped_text = wrap_math(alttext, display=True)
-                    new_span = build_cc_element(html_tag_name=new_tag, text=wrapped_text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
-                    parent.replace(node, new_span)
+                wrapped_text = wrap_math(alttext, display=True)
+                new_span = build_cc_element(html_tag_name=new_tag, text=wrapped_text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
+                parent.replace(node, new_span)
         else:
-            math_type = MathType.MATHML
-            equation_type = cm.get_equation_type(o_html)
-            if equation_type == EQUATION_INLINE:
-                new_tag = CCMATH_INLINE
-            elif equation_type == EQUATION_INTERLINE:
-                new_tag = CCMATH_INTERLINE
-            else:
-                raise ValueError(f'Unknown equation type: {equation_type}')
             # Try translating to LaTeX
             tmp_node = deepcopy(node)
             tmp_node.tail = None

--- a/llm_web_kit/pipeline/extractor/html/recognizer/cc_math/tag_span_mathcontainer.py
+++ b/llm_web_kit/pipeline/extractor/html/recognizer/cc_math/tag_span_mathcontainer.py
@@ -1,4 +1,4 @@
-from lxml import etree
+from lxml.html import HtmlElement
 
 from llm_web_kit.libs.html_utils import build_cc_element
 from llm_web_kit.libs.logger import logger
@@ -7,21 +7,19 @@ from llm_web_kit.pipeline.extractor.html.recognizer.cc_math.common import (
     EQUATION_INTERLINE, text_strip)
 
 
-def modify_tree(cm: CCMATH, math_render: str, o_html: str, node: etree._Element, parent: etree._Element):
+def modify_tree(cm: CCMATH, math_render: str, o_html: str, node: HtmlElement, parent: HtmlElement):
     try:
         text = node.text
-        equation_type = cm.get_equation_type(o_html)
+        equation_type, math_type = cm.get_equation_type(o_html)
+        if equation_type == EQUATION_INLINE:
+            new_tag = CCMATH_INLINE
+        elif equation_type == EQUATION_INTERLINE:
+            new_tag = CCMATH_INTERLINE
+        else:
+            raise ValueError(f'Unknown equation type: {equation_type}')
 
         if text and text_strip(text):
-            contains_math, math_type = cm.contains_math(text)
-            if contains_math:
-                if equation_type == EQUATION_INLINE:
-                    new_tag = CCMATH_INLINE
-                elif equation_type == EQUATION_INTERLINE:
-                    new_tag = CCMATH_INTERLINE
-                else:
-                    raise ValueError(f'Unknown equation type: {equation_type}')
-                new_span = build_cc_element(html_tag_name=new_tag, text=text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
-                parent.replace(node, new_span)
+            new_span = build_cc_element(html_tag_name=new_tag, text=text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
+            parent.replace(node, new_span)
     except Exception as e:
         logger.error(f'Error processing math-container class: {e}')

--- a/llm_web_kit/pipeline/extractor/html/recognizer/cc_math/tag_span_mathjax.py
+++ b/llm_web_kit/pipeline/extractor/html/recognizer/cc_math/tag_span_mathjax.py
@@ -1,4 +1,4 @@
-from lxml import etree
+from lxml.html import HtmlElement
 
 from llm_web_kit.libs.html_utils import build_cc_element
 from llm_web_kit.libs.logger import logger
@@ -7,7 +7,7 @@ from llm_web_kit.pipeline.extractor.html.recognizer.cc_math.common import (
     EQUATION_INTERLINE, text_strip)
 
 
-def modify_tree(cm: CCMATH, math_render: str, o_html: str, node: etree._Element, parent: etree._Element):
+def modify_tree(cm: CCMATH, math_render: str, o_html: str, node: HtmlElement, parent: HtmlElement):
     # 如果节点是span标签，并且class属性包含mathjax，MathJax，mathjax_display，MathJax_Display等
     # 示例：
     # <span class="mathjax">
@@ -22,19 +22,16 @@ def modify_tree(cm: CCMATH, math_render: str, o_html: str, node: etree._Element,
         #     ''.join([etree.tostring(child, encoding='utf-8', method='text').decode() for child in node])
         # ])
         text = node.text
-        equation_type = cm.get_equation_type(o_html)
+        equation_type, math_type = cm.get_equation_type(o_html)
+        if equation_type == EQUATION_INLINE:
+            new_tag = CCMATH_INLINE
+        elif equation_type == EQUATION_INTERLINE:
+            new_tag = CCMATH_INTERLINE
+        else:
+            raise ValueError(f'Unknown equation type: {equation_type}')
 
         if text and text_strip(text):
-            equation_type = cm.get_equation_type(text)
-            contains_math, math_type = cm.contains_math(text)
-            if contains_math:
-                if equation_type == EQUATION_INLINE:
-                    new_tag = CCMATH_INLINE
-                elif equation_type == EQUATION_INTERLINE:
-                    new_tag = CCMATH_INTERLINE
-                else:
-                    raise ValueError(f'Unknown equation type: {equation_type}')
-                new_span = build_cc_element(html_tag_name=new_tag, text=text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
-                parent.replace(node, new_span)
+            new_span = build_cc_element(html_tag_name=new_tag, text=text, tail=text_strip(node.tail), type=math_type, by=math_render, html=o_html)
+            parent.replace(node, new_span)
     except Exception as e:
         logger.error(f'Error processing mathjax class: {e}')

--- a/tests/llm_web_kit/pipeline/extractor/html/recognizer/test_math.py
+++ b/tests/llm_web_kit/pipeline/extractor/html/recognizer/test_math.py
@@ -31,19 +31,16 @@ TEST_CASES = [
         ),
         'expected': [
             (
-                '<html><body><p>这是p的text</p></body></html>',
-                '<html><body><p>这是p的text</p></body></html>'
+                '<p>这是p的text</p>',
+                '<p>这是p的text</p>'
             ),
             (
-                '<html><body><p><ccmath-interline type="latex" by="mathjax" '
-                'html="&lt;span class=&quot;mathjax_display&quot;&gt;$$a^2 + b^2 = c^2$$'
-                '&lt;/span&gt;&#x8FD9;&#x662F;span&#x7684;tail">$$a^2 + b^2 = c^2$$'
-                '</ccmath-interline></p></body></html>',
+                '<p><ccmath-interline type="latex" by="mathjax" html=\'&lt;span class="mathjax_display"&gt;$$a^2 + b^2 = c^2$$&lt;/span&gt;这是span的tail\'>$$a^2 + b^2 = c^2$$</ccmath-interline></p>',
                 '<span class="mathjax_display">$$a^2 + b^2 = c^2$$</span>这是span的tail'
             ),
             (
-                '<html><body><p>这是span的tail<b>这是b的text</b>这是b的tail</p></body></html>',
-                '<html><body><p>这是span的tail<b>这是b的text</b>这是b的tail</p></body></html>'
+                '<p>这是span的tail<b>这是b的text</b>这是b的tail</p>',
+                '<p>这是span的tail<b>这是b的text</b>这是b的tail</p>'
             )
         ]
     },
@@ -135,19 +132,31 @@ TEST_CASES_HTML = [
 TEST_EQUATION_TYPE = [
     {
         'input': '<span>$$a^2 + b^2 = c^2$$</span>',
-        'expected': 'equation-interline'
+        'expected': ('equation-interline', 'latex')
     },
     {
         'input': '<span>$a^2 + b^2 = c^2$</span>',
-        'expected': 'equation-inline'
+        'expected': ('equation-inline', 'latex')
     },
     {
         'input': '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>a</mi><mo>&#x2260;</mo><mn>0</mn></math>',
-        'expected': 'equation-inline'
+        'expected': ('equation-inline', 'mathml')
     },
     {
         'input': '<math xmlns="http://www.w3.org/1998/Math/MathML" display="block"><mi>a</mi><mo>&#x2260;</mo><mn>0</mn></math>',
-        'expected': 'equation-interline'
+        'expected': ('equation-interline', 'mathml')
+    },
+    {
+        'input': '<span>x<sub>1</sub> + x<sup>2</sup></span>',
+        'expected': ('equation-inline', 'htmlmath')
+    },
+    # {
+    #     'input': '<p>Matrices: <code>[[a,b],[c,d]]</code> yields to `[[a,b],[c,d]]`</p>',
+    #     'expected': ('equation-inline', 'asciimath')
+    # },
+    {
+        'input': '<p>Matrices: <code>[[a,b],[c,d]]</code> </p>',
+        'expected': (None, None)
     }
 ]
 
@@ -167,29 +176,6 @@ TEST_CONTENT_LIST_NODE = [
                 'by': 'mathjax'
             }
         }
-    }
-]
-
-TEST_CONTAINS_MATH = [
-    {
-        'input': '<span>$$x^2$$</span>',
-        'expected': (True, 'latex')
-    },
-    {
-        'input': '<span>x<sub>1</sub> + x<sup>2</sup></span>',
-        'expected': (True, 'htmlmath')
-    },
-    # {
-    #     'input': '<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>',
-    #     'expected': (True, 'mathml')
-    # },
-    {
-        'input': '<p>Matrices: <code>[[a,b],[c,d]]</code> yields to `[[a,b],[c,d]]`</p>',
-        'expected': (True, 'asciimath')
-    },
-    {
-        'input': '<p>Matrices: <code>[[a,b],[c,d]]</code> </p>',
-        'expected': (False, None)
     }
 ]
 
@@ -226,9 +212,9 @@ class TestMathRecognizer(unittest.TestCase):
                     test_case['raw_html']
                 )
                 print(output_html)
-                self.assertEqual(len(output_html), len(test_case['expected']))
+                self.assertEqual(len(output_html), len(test_case['expected']), msg=f'result is: {len(output_html)}, expected is: {len(test_case["expected"])}')
                 for i in range(len(output_html)):
-                    self.assertEqual(output_html[i], test_case['expected'][i])
+                    self.assertEqual(output_html[i], test_case['expected'][i], msg=f'result is: {output_html[i]}, expected is: {test_case["expected"][i]}')
 
     def test_math_recognizer_html(self):
         for test_case in TEST_CASES_HTML:
@@ -253,19 +239,6 @@ class TestMathRecognizer(unittest.TestCase):
                 print('answer::::::::', answer)
                 # print('expect::::::::', expect)
                 self.assertEqual(expect, answer)
-
-    # def test_get_math_render(self):
-    #     for test_case in TEST_GET_MATH_RENDER:
-    #         raw_html_path = base_dir.joinpath(test_case['input'][0])
-    #         raw_html = raw_html_path.read_text()
-    #         output_render = self.math_recognizer.get_math_render(raw_html)
-    #         self.assertEqual(output_render, test_case['expected'])
-
-    # def test_get_equation_type(self):
-    #     for test_case in TEST_EQUATION_TYPE:
-    #         with self.subTest(input=test_case['input']):
-    #             output_type = self.math_recognizer.get_equation_type(test_case['input'])
-    #             self.assertEqual(output_type, test_case['expected'])
 
     def test_to_content_list_node(self):
         for test_case in TEST_CONTENT_LIST_NODE:
@@ -299,14 +272,10 @@ class TestCCMATH(unittest.TestCase):
     def test_get_equation_type(self):
         for test_case in TEST_EQUATION_TYPE:
             with self.subTest(input=test_case['input']):
-                output_type = self.ccmath.get_equation_type(test_case['input'])
-                self.assertEqual(output_type, test_case['expected'])
-
-    def test_contains_math(self):
-        for test_case in TEST_CONTAINS_MATH:
-            with self.subTest(input=test_case['input']):
-                output_contains_math = self.ccmath.contains_math(test_case['input'])
-                self.assertEqual(output_contains_math, test_case['expected'])
+                equation_type, math_type = self.ccmath.get_equation_type(test_case['input'])
+                print('input::::::::', test_case['input'])
+                self.assertEqual(equation_type, test_case['expected'][0], msg=f'result is: {equation_type}, expected is: {test_case["expected"][0]}')
+                self.assertEqual(math_type, test_case['expected'][1], msg=f'result is: {math_type}, expected is: {test_case["expected"][1]}')
 
     def test_get_math_render(self):
         for test_case in TEST_GET_MATH_RENDER:
@@ -331,3 +300,7 @@ if __name__ == '__main__':
     # tree = build_html_tree(raw_html)
     # for node in tree.iter():
     #     print(node.tag)
+
+    c = TestCCMATH()
+    c.setUp()
+    c.test_get_equation_type()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

1. math模块html解析统一切换为lxml.html库，且解决ut问题；
2. 合并了math类型和行内行间公式获取方法；

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
