### PR TITLE
lang_id_fasttext_218_version

### DIFF
--- a/llm_web_kit/model/lang_id.py
+++ b/llm_web_kit/model/lang_id.py
@@ -11,7 +11,30 @@ from llm_web_kit.model.resource_utils.download_assets import (
 from llm_web_kit.model.resource_utils.singleton_resource_manager import \
     singleton_resource_manager
 
-
+language_dict = {
+    'srp': 'sr', 'swe': 'sv', 'dan': 'da', 'ita': 'it', 'spa': 'es', 'pes': 'fa', 'slk': 'sk', 'hun': 'hu', 'bul': 'bg', 'cat': 'ca',
+    'tur': 'tr', 'ell': 'el', 'eng': 'en', 'nob': 'no', 'fra': 'fr', 'rus': 'ru', 'hrv': 'hr', 'nld': 'nl', 'ind': 'id', 'hye': 'hy',
+    'heb': 'he', 'ceb': 'ceb', 'ron': 'ro', 'pol': 'pl', 'kor': 'ko', 'vie': 'vi', 'deu': 'de', 'slv': 'sl', 'por': 'pt', 'ces': 'cs',
+    'ukr': 'uk', 'fin': 'fi', 'arb': 'ar', 'tgl': 'tl', 'afr': 'af', 'est': 'et', 'war': 'war', 'zul': 'zu', 'lit': 'lt', 'ilo': 'ilo',
+    'kat': 'ka', 'hin': 'hi', 'mkd': 'mk', 'swh': 'sw', 'epo': 'eo', 'sot': 'st', 'tsn': 'tn', 'xho': 'xh', 'lvs': 'lv', 'als': 'als',
+    'tso': 'ts', 'kaz': 'kk', 'sna': 'sn', 'amh': 'am', 'zsm': 'ms', 'tha': 'th', 'tah': 'ty', 'nso': 'nso', 'ewe': 'ee', 'urd': 'ur',
+    'isl': 'is', 'lin': 'ln', 'bis': 'bi', 'twi': 'tw', 'sin': 'si', 'ben': 'bn', 'mya': 'my', 'plt': 'mg', 'pan': 'pa', 'azj': 'az',
+    'guj': 'gu', 'glg': 'gl', 'kir': 'ky', 'tel': 'te', 'tpi': 'tpi', 'ibo': 'ig', 'tam': 'ta', 'tat': 'tt', 'bem': 'bem', 'bel': 'be',
+    'kin': 'rw', 'npi': 'ne', 'pap': 'pap', 'mar': 'mr', 'smo': 'sm', 'run': 'rn', 'che': 'ce', 'fij': 'fj', 'tir': 'ti', 'ast': 'ast',
+    'kan': 'kn', 'mlt': 'mt', 'yor': 'yo', 'eus': 'eu', 'lua': 'lua', 'pag': 'pag', 'sag': 'sg', 'oss': 'os', 'khk': 'mn', 'tum': 'tum',
+    'tgk': 'tg', 'lug': 'lg', 'mal': 'ml', 'umb': 'umb', 'hat': 'ht', 'kon': 'kg', 'azb': 'azb', 'hau': 'ha', 'mos': 'mos', 'kal': 'kl',
+    'nno': 'nn', 'lus': 'lus', 'oci': 'oc', 'bos': 'bs', 'gaz': 'gaz', 'bak': 'ba', 'chv': 'cv', 'cym': 'cy', 'tuk': 'tk', 'luo': 'luo',
+    'ayr': 'ay', 'ssw': 'ss', 'quy': 'qu', 'uzn': 'uz', 'kik': 'ki', 'kmb': 'kmb', 'jav': 'jv', 'ltz': 'lb', 'asm': 'as', 'ton': 'to',
+    'nya': 'ny', 'kam': 'kam', 'ckb': 'ckb', 'min': 'min', 'bod': 'bo', 'lmo': 'lmo', 'gle': 'ga', 'sun': 'su', 'xmf': 'xmf', 'cjk': 'cjk',
+    'nia': 'nia', 'kbp': 'kbp', 'ory': 'or', 'fon': 'fon', 'kmr': 'ku', 'khm': 'km', 'ydd': 'yi', 'abk': 'ab', 'san': 'sa', 'uig': 'ug',
+    'lim': 'li', 'scn': 'scn', 'mai': 'mai', 'snd': 'sd', 'wes': 'wes', 'pcm': 'pcm', 'arn': 'arn', 'vec': 'vec', 'nav': 'nv', 'gom': 'gom',
+    'gla': 'gd', 'yue': 'zh', 'dyu': 'dyu', 'kac': 'kac', 'roh': 'rm', 'udm': 'udm', 'lao': 'lo', 'diq': 'diq', 'som': 'so', 'kab': 'kab',
+    'bjn': 'bjn', 'bxr': 'bxr', 'knc': 'knc', 'szl': 'szl', 'kea': 'kea', 'ban': 'ban', 'crh': 'crh', 'bug': 'bug', 'fur': 'fur', 'ace': 'ace',
+    'fuv': 'fuv', 'prs': 'prs', 'mri': 'mi', 'dik': 'dik', 'taq': 'taq', 'kas': 'kas', 'pbt': 'pbt', 'tzm': 'tzm', 'bam': 'bm', 'mag': 'mag',
+    'hne': 'hne', 'nus': 'nus', 'krc': 'krc', 'bho': 'bho', 'mni': 'mni', 'ltg': 'ltg', 'alt': 'alt', 'dzo': 'dz', 'lij': 'lij', 'wol': 'wo',
+    'sat': 'sat', 'jpn': 'ja', 'shn': 'shn', 'grn': 'gn', 'fao': 'fo', 'zho': 'zh', 'awa': 'awa', 'aka': 'ak', 'ewo': 'ewo', 'srd': 'sc',
+    'ady': 'ady'
+}
 class LanguageIdentification:
     """Language Identification model using fasttext."""
 
@@ -23,7 +46,7 @@ class LanguageIdentification:
             model_path (str, optional): Path to the model. Defaults to None.
         """
 
-        if not model_path:
+        if model_path is None:
             model_path = self.auto_download()
         self.model = fasttext.load_model(model_path)
 
@@ -84,21 +107,27 @@ class LanguageIdentification:
         return predictions, probabilities
 
 
-def get_singleton_lang_detect() -> LanguageIdentification:
+def get_singleton_lang_detect(model_path: str = None) -> LanguageIdentification:
     """Get the singleton language identification model.
 
-    returns:
+    Args:
+        model_path (str, optional): Path to the model. Defaults to None.
+
+    Returns:
         LanguageIdentification: The language identification model
     """
-    if not singleton_resource_manager.has_name('lang_detect'):
-        singleton_resource_manager.set_resource('lang_detect', LanguageIdentification())
-    return singleton_resource_manager.get_resource('lang_detect')
+    # 基于 model_path 生成唯一的单例名称
+    singleton_name = f'lang_detect_{model_path}' if model_path else 'lang_detect_default'
+    
+    if not singleton_resource_manager.has_name(singleton_name):
+        singleton_resource_manager.set_resource(singleton_name, LanguageIdentification(model_path))
+    return singleton_resource_manager.get_resource(singleton_name)
 
 
 def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[float]) -> str:
     """Decide language based on probabilities The rules are tuned by Some
-    sepciific data sources This is a fixed version for fasttext 176 model.
-
+    sepciific data sources.Now the function supports the lid218 model and outputs the language code of lid176
+    
     Args:
         predictions (Tuple[str]): the predicted languages labels by 176.bin model (__label__zh, __label__en, etc)
         probabilities (Tuple[float]): the probabilities of the predicted languages
@@ -107,10 +136,22 @@ def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[f
         str: the final language label
     """
     lang_prob_dict = {}
+    # Regular expression to match both formats
+    pattern_176 = re.compile(r'^__label__([a-z]+)$')  # Matches __label__en
+    pattern_218 = re.compile(r'^__label__([a-z]+)_[A-Za-z]+$')  # Matches __label__eng__Latn
     for lang_key, lang_prob in zip(predictions, probabilities):
-        lang = lang_key.replace('__label__', '')
-        lang_prob_dict[lang] = lang_prob
-
+        if pattern_176.match(lang_key):
+            lang = lang_key.replace("__label__", "")
+        elif pattern_218.match(lang_key):
+            label_without_prefix = lang_key.replace("__label__", "")
+            lang_code = label_without_prefix.split("_")[0]
+            lang = language_dict.get(lang_code, lang_code)
+        else:
+            raise ValueError(f'Unsupported prediction format: {lang_key}')
+        if lang in lang_prob_dict:
+            lang_prob_dict[lang] += lang_prob
+        else:
+            lang_prob_dict[lang] = lang_prob
     zh_prob = lang_prob_dict.get('zh', 0)
     en_prob = lang_prob_dict.get('en', 0)
     zh_en_prob = zh_prob + en_prob
@@ -131,8 +172,7 @@ def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[f
             final_lang = 'mix'
     return final_lang
 
-
-LANG_ID_SUPPORTED_VERSIONS = ['176.bin']
+LANG_ID_SUPPORTED_VERSIONS = ['176.bin', '218.bin']
 
 
 def detect_code_block(content_str: str) -> bool:
@@ -195,7 +235,7 @@ def decide_language_func(content_str: str, lang_detect: LanguageIdentification) 
     if len(content_str.strip()) == 0:
         return 'empty'
 
-    if lang_detect.version == '176.bin':
+    if lang_detect.version in ['176.bin', '218.bin']:
         predictions, probabilities = lang_detect.predict(content_str)
         result = decide_language_by_prob_v176(predictions, probabilities)
     else:
@@ -203,37 +243,42 @@ def decide_language_func(content_str: str, lang_detect: LanguageIdentification) 
     return result
 
 
-def decide_lang_by_str(content_str: str) -> str:
+def decide_lang_by_str(content_str: str, model_path: str = None) -> str:
     """Decide language based on the content string, based on
     decide_language_func."""
-    lang_detect = get_singleton_lang_detect()
+    lang_detect = get_singleton_lang_detect(model_path)
 
     return decide_language_func(content_str, lang_detect)
 
+def decide_lang_by_str_v218(content_str: str, model_path: str = None) -> str:
+    """Decide language based on the content string, displayed in the format of the fasttext218 model"""
+    lang_detect = get_singleton_lang_detect(model_path)
+    return {'language_detail': lang_detect.predict(content_str)[0][0].replace("__label__", "")}
 
-def update_language_by_str(content_str: str) -> str:
-    """Decide language based on the content string, based on
-    decide_language_func."""
-    return {'language': decide_lang_by_str(content_str)}
+def update_language_by_str(content_str: str, model_path: str = None) -> str:
+    """Decide language based on the content string."""
+    return {'language': decide_lang_by_str(content_str,model_path)}
 
 
 if __name__ == '__main__':
-    li = LanguageIdentification()
+    model_path = '/home/huyucheng/Downloads/lid218e.bin'
+    li = LanguageIdentification(model_path)
     print(li.version)
     text = 'hello world, this is a test. the language is english'
     predictions, probabilities = li.predict(text)
+    
     print(predictions, probabilities)
-
-    print(update_language_by_str(text))
-
+    
+    print(update_language_by_str(text,model_path))
+    print(decide_lang_by_str_v218(text,model_path))
     text = '你好，这是一个测试。这个语言是中文'
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))
 
     text = "```python\nprint('hello world')\n``` 这是一个中文的文档，包含了一些代码"
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))
 
     text = '$$x^2 + y^2 = 1$$ これは数式を含むテストドキュメントです'
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))
 
     text = '\\begin{equation}\n x^2 + y^2 = 1 \n\\end{equation} This is a test document, including some math equations'
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))


### PR DESCRIPTION
新增了fasttext218语言识别模型的代码,通过language_dict将218模型的language code映射到176模型的language code,可以保证语言代码和之前176版本一致.
如果需要调用lid218模型,请在update_language_by_str中增加model_path参数,默认使用.jsonc文件中的模型,新增decide_lang_by_str_v218函数可以查看语言的详细信息