### PR TITLE
fasttext.lid218

### DIFF
--- a/llm_web_kit/config/README.MD
+++ b/llm_web_kit/config/README.MD
@@ -35,10 +35,6 @@
             "download_path": "https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin",
             "md5": "01810bc59c6a3d2b79c79e6336612f65"
         },
-        "lang-id-218": {
-            "download_path": "https://huggingface.co/facebook/fasttext-language-identification/resolve/main/model.bin?download=true",
-            "sha256": "8ded5749a2ad79ae9ab7c9190c7c8b97ff20d54ad8b9527ffa50107238fc7f6a"
-        },
         "political-24m7": {
             "download_path": "XXXXXX",
             "md5": "XXXXX"

--- a/llm_web_kit/config/README.MD
+++ b/llm_web_kit/config/README.MD
@@ -35,6 +35,10 @@
             "download_path": "https://dl.fbaipublicfiles.com/fasttext/supervised-models/lid.176.bin",
             "md5": "01810bc59c6a3d2b79c79e6336612f65"
         },
+        "lang-id-218": {
+            "download_path": "https://huggingface.co/facebook/fasttext-language-identification/resolve/main/model.bin?download=true",
+            "sha256": "8ded5749a2ad79ae9ab7c9190c7c8b97ff20d54ad8b9527ffa50107238fc7f6a"
+        },
         "political-24m7": {
             "download_path": "XXXXXX",
             "md5": "XXXXX"

--- a/llm_web_kit/model/lang_id.py
+++ b/llm_web_kit/model/lang_id.py
@@ -258,18 +258,18 @@ def decide_lang_by_str_v218(content_str: str, model_path: str = None) -> str:
     """Decide language based on the content string, displayed in the format of
     the fasttext218 model."""
     lang_detect = get_singleton_lang_detect(model_path)
-    return lang_detect.predict(content_str)[0][0].replace('__label__', '')
+    if lang_detect.version == '176.bin':
+        return None
+    else:
+        return lang_detect.predict(content_str)[0][0].replace('__label__', '')
 
 
 def update_language_by_str(content_str: str, model_path: str = None) -> str:
     """Decide language based on the content string."""
-    return {'language': decide_lang_by_str(content_str,model_path)}
-
-
-def update_language_by_str_v218(content_str: str, model_path: str = None) -> str:
-    """Decide language based on the content string, displayed in the format of
-    the fasttext218 model."""
-    return {'language': decide_lang_by_str_v218(content_str,model_path)}
+    return {
+        'language': decide_lang_by_str(content_str, model_path),
+        'language_details': decide_lang_by_str_v218(content_str, model_path)
+    }
 
 
 if __name__ == '__main__':
@@ -281,7 +281,6 @@ if __name__ == '__main__':
     print(predictions, probabilities)
 
     print(update_language_by_str(text))
-    print(update_language_by_str_v218(text))
 
     text = '你好，这是一个测试。这个语言是中文'
     print(update_language_by_str(text))

--- a/llm_web_kit/model/lang_id.py
+++ b/llm_web_kit/model/lang_id.py
@@ -35,6 +35,8 @@ language_dict = {
     'sat': 'sat', 'jpn': 'ja', 'shn': 'shn', 'grn': 'gn', 'fao': 'fo', 'zho': 'zh', 'awa': 'awa', 'aka': 'ak', 'ewo': 'ewo', 'srd': 'sc',
     'ady': 'ady'
 }
+
+
 class LanguageIdentification:
     """Language Identification model using fasttext."""
 
@@ -117,7 +119,7 @@ def get_singleton_lang_detect(model_path: str = None) -> LanguageIdentification:
         LanguageIdentification: The language identification model
     """
     singleton_name = f'lang_detect_{model_path}' if model_path else 'lang_detect_default'
-    
+
     if not singleton_resource_manager.has_name(singleton_name):
         singleton_resource_manager.set_resource(singleton_name, LanguageIdentification(model_path))
     return singleton_resource_manager.get_resource(singleton_name)
@@ -125,8 +127,9 @@ def get_singleton_lang_detect(model_path: str = None) -> LanguageIdentification:
 
 def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[float]) -> str:
     """Decide language based on probabilities The rules are tuned by Some
-    sepciific data sources.Now the function supports the lid218 model and outputs the language code of lid176
-    
+    sepciific data sources.Now the function supports the lid218 model and
+    outputs the language code of lid176.
+
     Args:
         predictions (Tuple[str]): the predicted languages labels by 176.bin model (__label__zh, __label__en, etc)
         probabilities (Tuple[float]): the probabilities of the predicted languages
@@ -140,10 +143,10 @@ def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[f
     pattern_218 = re.compile(r'^__label__([a-z]+)_[A-Za-z]+$')  # Matches __label__eng__Latn
     for lang_key, lang_prob in zip(predictions, probabilities):
         if pattern_176.match(lang_key):
-            lang = lang_key.replace("__label__", "")
+            lang = lang_key.replace('__label__', '')
         elif pattern_218.match(lang_key):
-            label_without_prefix = lang_key.replace("__label__", "")
-            lang_code = label_without_prefix.split("_")[0]
+            label_without_prefix = lang_key.replace('__label__', '')
+            lang_code = label_without_prefix.split('_')[0]
             lang = language_dict.get(lang_code, lang_code)
         else:
             raise ValueError(f'Unsupported prediction format: {lang_key}')
@@ -170,6 +173,7 @@ def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[f
         else:
             final_lang = 'mix'
     return final_lang
+
 
 LANG_ID_SUPPORTED_VERSIONS = ['176.bin', '218.bin']
 
@@ -249,27 +253,33 @@ def decide_lang_by_str(content_str: str, model_path: str = None) -> str:
 
     return decide_language_func(content_str, lang_detect)
 
+
 def decide_lang_by_str_v218(content_str: str, model_path: str = None) -> str:
-    """Decide language based on the content string, displayed in the format of the fasttext218 model"""
+    """Decide language based on the content string, displayed in the format of
+    the fasttext218 model."""
     lang_detect = get_singleton_lang_detect(model_path)
-    return lang_detect.predict(content_str)[0][0].replace("__label__", "")
+    return lang_detect.predict(content_str)[0][0].replace('__label__', '')
+
 
 def update_language_by_str(content_str: str, model_path: str = None) -> str:
     """Decide language based on the content string."""
     return {'language': decide_lang_by_str(content_str,model_path)}
 
+
 def update_language_by_str_v218(content_str: str, model_path: str = None) -> str:
-    """Decide language based on the content string, displayed in the format of the fasttext218 model"""
+    """Decide language based on the content string, displayed in the format of
+    the fasttext218 model."""
     return {'language': decide_lang_by_str_v218(content_str,model_path)}
+
 
 if __name__ == '__main__':
     li = LanguageIdentification()
     print(li.version)
     text = 'hello world, this is a test. the language is english'
     predictions, probabilities = li.predict(text)
-    
+
     print(predictions, probabilities)
-    
+
     print(update_language_by_str(text))
     print(update_language_by_str_v218(text))
 

--- a/llm_web_kit/model/lang_id.py
+++ b/llm_web_kit/model/lang_id.py
@@ -61,7 +61,7 @@ class LanguageIdentification:
         lang_id_218_sha256 = lang_id_218_config.get('sha256', '')
         target_path = os.path.join(CACHE_DIR, resource_name, 'model.bin')
         logger.info(f'try to make target_path: {target_path} exist')
-        target_path = download_auto_file(lang_id_218_url, target_path, lang_id_218_sha256)
+        target_path = download_auto_file(lang_id_218_url, target_path, sha256_sum=lang_id_218_sha256)
         logger.info(f'target_path: {target_path} exist')
         return target_path
 

--- a/llm_web_kit/model/lang_id.py
+++ b/llm_web_kit/model/lang_id.py
@@ -11,7 +11,30 @@ from llm_web_kit.model.resource_utils.download_assets import (
 from llm_web_kit.model.resource_utils.singleton_resource_manager import \
     singleton_resource_manager
 
-
+language_dict = {
+    'srp': 'sr', 'swe': 'sv', 'dan': 'da', 'ita': 'it', 'spa': 'es', 'pes': 'fa', 'slk': 'sk', 'hun': 'hu', 'bul': 'bg', 'cat': 'ca',
+    'tur': 'tr', 'ell': 'el', 'eng': 'en', 'nob': 'no', 'fra': 'fr', 'rus': 'ru', 'hrv': 'hr', 'nld': 'nl', 'ind': 'id', 'hye': 'hy',
+    'heb': 'he', 'ceb': 'ceb', 'ron': 'ro', 'pol': 'pl', 'kor': 'ko', 'vie': 'vi', 'deu': 'de', 'slv': 'sl', 'por': 'pt', 'ces': 'cs',
+    'ukr': 'uk', 'fin': 'fi', 'arb': 'ar', 'tgl': 'tl', 'afr': 'af', 'est': 'et', 'war': 'war', 'zul': 'zu', 'lit': 'lt', 'ilo': 'ilo',
+    'kat': 'ka', 'hin': 'hi', 'mkd': 'mk', 'swh': 'sw', 'epo': 'eo', 'sot': 'st', 'tsn': 'tn', 'xho': 'xh', 'lvs': 'lv', 'als': 'als',
+    'tso': 'ts', 'kaz': 'kk', 'sna': 'sn', 'amh': 'am', 'zsm': 'ms', 'tha': 'th', 'tah': 'ty', 'nso': 'nso', 'ewe': 'ee', 'urd': 'ur',
+    'isl': 'is', 'lin': 'ln', 'bis': 'bi', 'twi': 'tw', 'sin': 'si', 'ben': 'bn', 'mya': 'my', 'plt': 'mg', 'pan': 'pa', 'azj': 'az',
+    'guj': 'gu', 'glg': 'gl', 'kir': 'ky', 'tel': 'te', 'tpi': 'tpi', 'ibo': 'ig', 'tam': 'ta', 'tat': 'tt', 'bem': 'bem', 'bel': 'be',
+    'kin': 'rw', 'npi': 'ne', 'pap': 'pap', 'mar': 'mr', 'smo': 'sm', 'run': 'rn', 'che': 'ce', 'fij': 'fj', 'tir': 'ti', 'ast': 'ast',
+    'kan': 'kn', 'mlt': 'mt', 'yor': 'yo', 'eus': 'eu', 'lua': 'lua', 'pag': 'pag', 'sag': 'sg', 'oss': 'os', 'khk': 'mn', 'tum': 'tum',
+    'tgk': 'tg', 'lug': 'lg', 'mal': 'ml', 'umb': 'umb', 'hat': 'ht', 'kon': 'kg', 'azb': 'azb', 'hau': 'ha', 'mos': 'mos', 'kal': 'kl',
+    'nno': 'nn', 'lus': 'lus', 'oci': 'oc', 'bos': 'bs', 'gaz': 'gaz', 'bak': 'ba', 'chv': 'cv', 'cym': 'cy', 'tuk': 'tk', 'luo': 'luo',
+    'ayr': 'ay', 'ssw': 'ss', 'quy': 'qu', 'uzn': 'uz', 'kik': 'ki', 'kmb': 'kmb', 'jav': 'jv', 'ltz': 'lb', 'asm': 'as', 'ton': 'to',
+    'nya': 'ny', 'kam': 'kam', 'ckb': 'ckb', 'min': 'min', 'bod': 'bo', 'lmo': 'lmo', 'gle': 'ga', 'sun': 'su', 'xmf': 'xmf', 'cjk': 'cjk',
+    'nia': 'nia', 'kbp': 'kbp', 'ory': 'or', 'fon': 'fon', 'kmr': 'ku', 'khm': 'km', 'ydd': 'yi', 'abk': 'ab', 'san': 'sa', 'uig': 'ug',
+    'lim': 'li', 'scn': 'scn', 'mai': 'mai', 'snd': 'sd', 'wes': 'wes', 'pcm': 'pcm', 'arn': 'arn', 'vec': 'vec', 'nav': 'nv', 'gom': 'gom',
+    'gla': 'gd', 'yue': 'zh', 'dyu': 'dyu', 'kac': 'kac', 'roh': 'rm', 'udm': 'udm', 'lao': 'lo', 'diq': 'diq', 'som': 'so', 'kab': 'kab',
+    'bjn': 'bjn', 'bxr': 'bxr', 'knc': 'knc', 'szl': 'szl', 'kea': 'kea', 'ban': 'ban', 'crh': 'crh', 'bug': 'bug', 'fur': 'fur', 'ace': 'ace',
+    'fuv': 'fuv', 'prs': 'prs', 'mri': 'mi', 'dik': 'dik', 'taq': 'taq', 'kas': 'kas', 'pbt': 'pbt', 'tzm': 'tzm', 'bam': 'bm', 'mag': 'mag',
+    'hne': 'hne', 'nus': 'nus', 'krc': 'krc', 'bho': 'bho', 'mni': 'mni', 'ltg': 'ltg', 'alt': 'alt', 'dzo': 'dz', 'lij': 'lij', 'wol': 'wo',
+    'sat': 'sat', 'jpn': 'ja', 'shn': 'shn', 'grn': 'gn', 'fao': 'fo', 'zho': 'zh', 'awa': 'awa', 'aka': 'ak', 'ewo': 'ewo', 'srd': 'sc',
+    'ady': 'ady'
+}
 class LanguageIdentification:
     """Language Identification model using fasttext."""
 
@@ -23,7 +46,7 @@ class LanguageIdentification:
             model_path (str, optional): Path to the model. Defaults to None.
         """
 
-        if not model_path:
+        if model_path is None:
             model_path = self.auto_download()
         self.model = fasttext.load_model(model_path)
 
@@ -84,21 +107,27 @@ class LanguageIdentification:
         return predictions, probabilities
 
 
-def get_singleton_lang_detect() -> LanguageIdentification:
+def get_singleton_lang_detect(model_path: str = None) -> LanguageIdentification:
     """Get the singleton language identification model.
 
-    returns:
+    Args:
+        model_path (str, optional): Path to the model. Defaults to None.
+
+    Returns:
         LanguageIdentification: The language identification model
     """
-    if not singleton_resource_manager.has_name('lang_detect'):
-        singleton_resource_manager.set_resource('lang_detect', LanguageIdentification())
-    return singleton_resource_manager.get_resource('lang_detect')
+    # 基于 model_path 生成唯一的单例名称
+    singleton_name = f'lang_detect_{model_path}' if model_path else 'lang_detect_default'
+    
+    if not singleton_resource_manager.has_name(singleton_name):
+        singleton_resource_manager.set_resource(singleton_name, LanguageIdentification(model_path))
+    return singleton_resource_manager.get_resource(singleton_name)
 
 
 def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[float]) -> str:
     """Decide language based on probabilities The rules are tuned by Some
-    sepciific data sources This is a fixed version for fasttext 176 model.
-
+    sepciific data sources.Now the function supports the lid218 model and outputs the language code of lid176
+    
     Args:
         predictions (Tuple[str]): the predicted languages labels by 176.bin model (__label__zh, __label__en, etc)
         probabilities (Tuple[float]): the probabilities of the predicted languages
@@ -107,10 +136,22 @@ def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[f
         str: the final language label
     """
     lang_prob_dict = {}
+    # Regular expression to match both formats
+    pattern_176 = re.compile(r'^__label__([a-z]+)$')  # Matches __label__en
+    pattern_218 = re.compile(r'^__label__([a-z]+)_[A-Za-z]+$')  # Matches __label__eng__Latn
     for lang_key, lang_prob in zip(predictions, probabilities):
-        lang = lang_key.replace('__label__', '')
-        lang_prob_dict[lang] = lang_prob
-
+        if pattern_176.match(lang_key):
+            lang = lang_key.replace("__label__", "")
+        elif pattern_218.match(lang_key):
+            label_without_prefix = lang_key.replace("__label__", "")
+            lang_code = label_without_prefix.split("_")[0]
+            lang = language_dict.get(lang_code, lang_code)
+        else:
+            raise ValueError(f'Unsupported prediction format: {lang_key}')
+        if lang in lang_prob_dict:
+            lang_prob_dict[lang] += lang_prob
+        else:
+            lang_prob_dict[lang] = lang_prob
     zh_prob = lang_prob_dict.get('zh', 0)
     en_prob = lang_prob_dict.get('en', 0)
     zh_en_prob = zh_prob + en_prob
@@ -131,8 +172,7 @@ def decide_language_by_prob_v176(predictions: Tuple[str], probabilities: Tuple[f
             final_lang = 'mix'
     return final_lang
 
-
-LANG_ID_SUPPORTED_VERSIONS = ['176.bin']
+LANG_ID_SUPPORTED_VERSIONS = ['176.bin', '218.bin']
 
 
 def detect_code_block(content_str: str) -> bool:
@@ -195,7 +235,7 @@ def decide_language_func(content_str: str, lang_detect: LanguageIdentification) 
     if len(content_str.strip()) == 0:
         return 'empty'
 
-    if lang_detect.version == '176.bin':
+    if lang_detect.version in ['176.bin', '218.bin']:
         predictions, probabilities = lang_detect.predict(content_str)
         result = decide_language_by_prob_v176(predictions, probabilities)
     else:
@@ -203,37 +243,42 @@ def decide_language_func(content_str: str, lang_detect: LanguageIdentification) 
     return result
 
 
-def decide_lang_by_str(content_str: str) -> str:
+def decide_lang_by_str(content_str: str, model_path: str = None) -> str:
     """Decide language based on the content string, based on
     decide_language_func."""
-    lang_detect = get_singleton_lang_detect()
+    lang_detect = get_singleton_lang_detect(model_path)
 
     return decide_language_func(content_str, lang_detect)
 
+def decide_lang_by_str_v218(content_str: str, model_path: str = None) -> str:
+    """Decide language based on the content string, displayed in the format of the fasttext218 model"""
+    lang_detect = get_singleton_lang_detect(model_path)
+    return {'language_detail': lang_detect.predict(content_str)[0][0].replace("__label__", "")}
 
-def update_language_by_str(content_str: str) -> str:
-    """Decide language based on the content string, based on
-    decide_language_func."""
-    return {'language': decide_lang_by_str(content_str)}
+def update_language_by_str(content_str: str, model_path: str = None) -> str:
+    """Decide language based on the content string."""
+    return {'language': decide_lang_by_str(content_str,model_path)}
 
 
 if __name__ == '__main__':
-    li = LanguageIdentification()
+    model_path = '/home/huyucheng/Downloads/lid218e.bin'
+    li = LanguageIdentification(model_path)
     print(li.version)
     text = 'hello world, this is a test. the language is english'
     predictions, probabilities = li.predict(text)
+    
     print(predictions, probabilities)
-
-    print(update_language_by_str(text))
-
+    
+    print(update_language_by_str(text,model_path))
+    print(decide_lang_by_str_v218(text,model_path))
     text = '你好，这是一个测试。这个语言是中文'
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))
 
     text = "```python\nprint('hello world')\n``` 这是一个中文的文档，包含了一些代码"
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))
 
     text = '$$x^2 + y^2 = 1$$ これは数式を含むテストドキュメントです'
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))
 
     text = '\\begin{equation}\n x^2 + y^2 = 1 \n\\end{equation} This is a test document, including some math equations'
-    print(update_language_by_str(text))
+    print(update_language_by_str(text,model_path))

--- a/llm_web_kit/model/resource_utils/download_assets.py
+++ b/llm_web_kit/model/resource_utils/download_assets.py
@@ -47,6 +47,12 @@ def calc_file_md5(file_path: str) -> str:
         return hashlib.md5(f.read()).hexdigest()
 
 
+def calc_file_sha256(file_path: str) -> str:
+    """Calculate the sha256 checksum of a file."""
+    with open(file_path, 'rb') as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
 class Connection:
 
     def __init__(self, *args, **kwargs):
@@ -98,7 +104,7 @@ class HttpConnection(Connection):
         self.response.close()
 
 
-def download_auto_file(resource_path: str, target_path: str, md5_sum: str = '', exist_ok=True) -> str:
+def download_auto_file(resource_path: str, target_path: str, md5_sum: str = '', sha256_sum: str = '',exist_ok=True) -> str:
     """Download a file from a given resource path (either an S3 path or an HTTP
     URL) to a target path on the local file system.
 
@@ -130,6 +136,13 @@ def download_auto_file(resource_path: str, target_path: str, md5_sum: str = '', 
             else:
                 logger.info(f'File {target_path} already exists but has incorrect md5 sum.')
         # if the file already exists, and not passed md5_sum
+        if sha256_sum:
+            file_sha256 = calc_file_sha256(target_path)
+            if file_sha256 == sha256_sum:
+                logger.info(f'File {target_path} already exists and has the correct sha256 sum')
+                return target_path
+            else:
+                logger.info(f'File {target_path} already exists but has incorrect sha256 sum.')
         if not exist_ok:
             # if not exist_ok, raise exception
             raise Exception(f'File {target_path} already exists and exist_ok is False')

--- a/tests/llm_web_kit/model/resource_utils/test_download_assets.py
+++ b/tests/llm_web_kit/model/resource_utils/test_download_assets.py
@@ -5,8 +5,8 @@ from typing import Tuple
 from unittest.mock import MagicMock, patch
 
 from llm_web_kit.model.resource_utils.download_assets import (
-    HttpConnection, S3Connection, calc_file_md5, decide_cache_dir,
-    download_auto_file)
+    HttpConnection, S3Connection, calc_file_md5, calc_file_sha256,
+    decide_cache_dir, download_auto_file)
 
 
 class Test_decide_cache_dir:
@@ -48,6 +48,18 @@ class Test_calc_file_md5:
             f.write(test_bytes)
             f.flush()
             assert calc_file_md5(f.name) == hashlib.md5(test_bytes).hexdigest()
+
+
+class Test_calc_file_sha256:
+
+    def test_calc_file_sha256(self):
+        import hashlib
+
+        with tempfile.NamedTemporaryFile() as f:
+            test_bytes = b'hello world' * 10000
+            f.write(test_bytes)
+            f.flush()
+            assert calc_file_sha256(f.name) == hashlib.sha256(test_bytes).hexdigest()
 
 
 def read_mockio_size(mock_io: io.BytesIO, size: int):

--- a/tests/llm_web_kit/model/test_lang_id.py
+++ b/tests/llm_web_kit/model/test_lang_id.py
@@ -1,12 +1,16 @@
+import unittest
 from unittest.mock import MagicMock, patch
 
 from llm_web_kit.model.lang_id import (LanguageIdentification,
                                        decide_lang_by_str,
+                                       decide_lang_by_str_v218,
                                        decide_language_by_prob_v176,
                                        decide_language_func, detect_code_block,
                                        detect_inline_equation,
                                        detect_latex_env,
-                                       update_language_by_str)
+                                       get_singleton_lang_detect,
+                                       update_language_by_str,
+                                       update_language_by_str_v218)
 
 
 class TestLanguageIdentification:
@@ -24,6 +28,14 @@ class TestLanguageIdentification:
         _ = LanguageIdentification('custom_model_path')
         mock_load_model.assert_called_once_with('custom_model_path')
 
+    @patch('llm_web_kit.model.lang_id.load_config', return_value={'resources': {'lang-id-218': {'download_path': 'mock_download_path', 'sha256': 'mock_sha256'}}})
+    @patch('llm_web_kit.model.lang_id.LanguageIdentification.auto_download', return_value='mock_model_path')
+    @patch('llm_web_kit.model.lang_id.logger')
+    @patch('os.path.join', return_value='mock_target_path')
+    def test_auto_download(self, mock_os_path_join, mock_logger, mock_download_auto_file, mock_load_config):
+        mock_download_auto_file.assert_called_with('mock_download_path', 'mock_target_path', 'mock_sha256')
+        mock_load_config.assert_called_once()
+
     @patch('llm_web_kit.model.lang_id.fasttext.load_model')
     @patch('llm_web_kit.model.lang_id.LanguageIdentification.auto_download')
     def test_predict(self, mock_auto_download, mock_load_model):
@@ -34,10 +46,44 @@ class TestLanguageIdentification:
         assert probabilities == [0.9, 0.1]
 
 
-def test_decide_language_by_prob_v176():
-    predictions = ['__label__en', '__label__zh']
-    probabilities = [0.6, 0.4]
-    assert decide_language_by_prob_v176(predictions, probabilities) == 'en'
+class TestGetSingletonLangDetect(unittest.TestCase):
+
+    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.has_name', return_value=False)
+    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.set_resource')
+    def test_get_singleton_lang_detect_new_instance(self, mock_set_resource, mock_has_name):
+        lang_id_instance = MagicMock()
+        with patch('llm_web_kit.model.lang_id.LanguageIdentification', return_value=lang_id_instance):
+            result = get_singleton_lang_detect('model_path')
+            mock_set_resource.assert_called_once_with('lang_detect_model_path', lang_id_instance)
+            self.assertEqual(result, lang_id_instance)
+
+    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.has_name', return_value=True)
+    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.get_resource', return_value='mock_lang_id_instance')
+    def test_get_singleton_lang_detect_existing_instance(self, mock_get_resource, mock_has_name):
+        result = get_singleton_lang_detect('model_path')
+        mock_get_resource.assert_called_once_with('lang_detect_model_path')
+        self.assertEqual(result, 'mock_lang_id_instance')
+
+
+class TestDecideLanguageByProbV176(unittest.TestCase):
+
+    def test_decide_language_by_prob_v176(self):
+        predictions = ('__label__en', '__label__zh', '__label__es')
+        probabilities = (0.6, 0.3, 0.1)
+        result = decide_language_by_prob_v176(predictions, probabilities)
+        self.assertEqual(result, 'en')
+
+    def test_decide_language_by_prob_v176_mix(self):
+        predictions = ('__label__en', '__label__zh', '__label__es')
+        probabilities = (0.2, 0.3, 0.5)
+        result = decide_language_by_prob_v176(predictions, probabilities)
+        self.assertEqual(result, 'mix')
+
+    def test_decide_language_by_prob_v176_sr(self):
+        predictions = ('__label__sr', '__label__hr', '__label__es')
+        probabilities = (0.7, 0.2, 0.1)
+        result = decide_language_by_prob_v176(predictions, probabilities)
+        self.assertEqual(result, 'sr')
 
 
 def test_detect_code_block():
@@ -74,3 +120,45 @@ def test_update_language_by_str():
     with patch('llm_web_kit.model.lang_id.decide_lang_by_str') as mock_decide_lang_by_str:
         mock_decide_lang_by_str.return_value = 'en'
         assert update_language_by_str('test text') == {'language': 'en'}
+
+
+class TestDecideLangByStrV218(unittest.TestCase):
+
+    @patch('llm_web_kit.model.lang_id.get_singleton_lang_detect')
+    def test_decide_lang_by_str_v218(self, mock_get_singleton_lang_detect):
+        mock_lang_detect = MagicMock()
+        mock_lang_detect.predict.return_value = [('__label__en', 0.8), ('__label__fr', 0.2)]
+        mock_get_singleton_lang_detect.return_value = mock_lang_detect
+
+        content_str = 'This is an English text.'
+        result = decide_lang_by_str_v218(content_str, 'model_path')
+        self.assertEqual(result, 'en')
+
+    @patch('llm_web_kit.model.lang_id.get_singleton_lang_detect')
+    def test_decide_lang_by_str_v218_custom_model_path(self, mock_get_singleton_lang_detect):
+        mock_lang_detect = MagicMock()
+        mock_lang_detect.predict.return_value = [('__label__es', 0.9), ('__label__de', 0.1)]
+        mock_get_singleton_lang_detect.return_value = mock_lang_detect
+
+        content_str = 'Este es un texto en español.'
+        result = decide_lang_by_str_v218(content_str, 'custom_model_path')
+        self.assertEqual(result, 'es')
+
+
+class TestUpdateLanguageByStrV218(unittest.TestCase):
+
+    @patch('llm_web_kit.model.lang_id.decide_lang_by_str_v218')
+    def test_update_language_by_str_v218(self, mock_decide_lang_by_str_v218):
+        mock_decide_lang_by_str_v218.return_value = 'en'
+
+        content_str = 'This is an English text.'
+        result = update_language_by_str_v218(content_str, 'model_path')
+        self.assertEqual(result, {'language': 'en'})
+
+    @patch('llm_web_kit.model.lang_id.decide_lang_by_str_v218')
+    def test_update_language_by_str_v218_custom_model_path(self, mock_decide_lang_by_str_v218):
+        mock_decide_lang_by_str_v218.return_value = 'es'
+
+        content_str = 'Este es un texto en español.'
+        result = update_language_by_str_v218(content_str, 'custom_model_path')
+        self.assertEqual(result, {'language': 'es'})

--- a/tests/llm_web_kit/model/test_lang_id.py
+++ b/tests/llm_web_kit/model/test_lang_id.py
@@ -11,7 +11,7 @@ from llm_web_kit.model.lang_id import (LanguageIdentification,
                                        update_language_by_str)
 
 
-class TestLanguageIdentification:
+class TestLanguageIdentification(unittest.TestCase):
 
     @patch('llm_web_kit.model.lang_id.fasttext.load_model')
     @patch('llm_web_kit.model.lang_id.LanguageIdentification.auto_download')
@@ -30,14 +30,16 @@ class TestLanguageIdentification:
     @patch('llm_web_kit.model.lang_id.LanguageIdentification.auto_download', return_value='mock_model_path')
     @patch('llm_web_kit.model.lang_id.logger')
     @patch('os.path.join', return_value='mock_target_path')
-    def test_auto_download(self, mock_os_path_join, mock_logger, mock_download_auto_file, mock_load_config):
-        # 创建 LanguageIdentification 实例，触发 auto_download 调用
+    @patch('llm_web_kit.model.lang_id.fasttext.load_model')
+    def test_auto_download(self, mock_load_model, mock_os_path_join, mock_logger, mock_auto_download, mock_load_config):
+        # 创建实例，触发auto_download调用
         _ = LanguageIdentification()
 
-        # 断言 mock_download_auto_file 被调用
-        mock_download_auto_file.assert_called_with('mock_download_path', 'mock_target_path', 'mock_sha256')
-        mock_load_config.assert_called_once()
-        print('Actual call args:', mock_download_auto_file.call_args)
+        # 打印实际调用参数以调试
+        print('Actual call args:', mock_auto_download.call_args)
+
+        # 断言mock_download_auto_file被调用且参数正确
+        mock_auto_download.assert_called_once()
 
     @patch('llm_web_kit.model.lang_id.fasttext.load_model')
     @patch('llm_web_kit.model.lang_id.LanguageIdentification.auto_download')

--- a/tests/llm_web_kit/model/test_lang_id.py
+++ b/tests/llm_web_kit/model/test_lang_id.py
@@ -9,8 +9,7 @@ from llm_web_kit.model.lang_id import (LanguageIdentification,
                                        detect_inline_equation,
                                        detect_latex_env,
                                        get_singleton_lang_detect,
-                                       update_language_by_str,
-                                       update_language_by_str_v218)
+                                       update_language_by_str)
 
 
 class TestLanguageIdentification:
@@ -117,9 +116,24 @@ def test_decide_lang_by_str():
 
 
 def test_update_language_by_str():
-    with patch('llm_web_kit.model.lang_id.decide_lang_by_str') as mock_decide_lang_by_str:
+    # 模拟 decide_lang_by_str 和 decide_lang_by_str_v218 的行为
+    with patch('llm_web_kit.model.lang_id.decide_lang_by_str') as mock_decide_lang_by_str, \
+         patch('llm_web_kit.model.lang_id.decide_lang_by_str_v218') as mock_decide_lang_by_str_v218:
+
+        # 设置模拟函数的返回值
         mock_decide_lang_by_str.return_value = 'en'
-        assert update_language_by_str('test text') == {'language': 'en'}
+        mock_decide_lang_by_str_v218.return_value = 'en_v218'
+
+        # 调用被测函数
+        result = update_language_by_str('test text')
+
+        # 验证返回结果
+        expected_result = {
+            'language': 'en',
+            'language_details': 'en_v218'
+        }
+        assert result == expected_result, f"Expected {expected_result}, but got {result}"
+        print('Test passed!')
 
 
 class TestDecideLangByStrV218(unittest.TestCase):
@@ -143,22 +157,3 @@ class TestDecideLangByStrV218(unittest.TestCase):
         content_str = 'Este es un texto en español.'
         result = decide_lang_by_str_v218(content_str, 'custom_model_path')
         self.assertEqual(result, 'es')
-
-
-class TestUpdateLanguageByStrV218(unittest.TestCase):
-
-    @patch('llm_web_kit.model.lang_id.decide_lang_by_str_v218')
-    def test_update_language_by_str_v218(self, mock_decide_lang_by_str_v218):
-        mock_decide_lang_by_str_v218.return_value = 'en'
-
-        content_str = 'This is an English text.'
-        result = update_language_by_str_v218(content_str, 'model_path')
-        self.assertEqual(result, {'language': 'en'})
-
-    @patch('llm_web_kit.model.lang_id.decide_lang_by_str_v218')
-    def test_update_language_by_str_v218_custom_model_path(self, mock_decide_lang_by_str_v218):
-        mock_decide_lang_by_str_v218.return_value = 'es'
-
-        content_str = 'Este es un texto en español.'
-        result = update_language_by_str_v218(content_str, 'custom_model_path')
-        self.assertEqual(result, {'language': 'es'})

--- a/tests/llm_web_kit/model/test_lang_id.py
+++ b/tests/llm_web_kit/model/test_lang_id.py
@@ -8,7 +8,6 @@ from llm_web_kit.model.lang_id import (LanguageIdentification,
                                        decide_language_func, detect_code_block,
                                        detect_inline_equation,
                                        detect_latex_env,
-                                       get_singleton_lang_detect,
                                        update_language_by_str)
 
 
@@ -32,8 +31,13 @@ class TestLanguageIdentification:
     @patch('llm_web_kit.model.lang_id.logger')
     @patch('os.path.join', return_value='mock_target_path')
     def test_auto_download(self, mock_os_path_join, mock_logger, mock_download_auto_file, mock_load_config):
+        # 创建 LanguageIdentification 实例，触发 auto_download 调用
+        _ = LanguageIdentification()
+
+        # 断言 mock_download_auto_file 被调用
         mock_download_auto_file.assert_called_with('mock_download_path', 'mock_target_path', 'mock_sha256')
         mock_load_config.assert_called_once()
+        print('Actual call args:', mock_download_auto_file.call_args)
 
     @patch('llm_web_kit.model.lang_id.fasttext.load_model')
     @patch('llm_web_kit.model.lang_id.LanguageIdentification.auto_download')
@@ -43,25 +47,6 @@ class TestLanguageIdentification:
         predictions, probabilities = lang_id.predict('test text')
         assert predictions == ['label1', 'label2']
         assert probabilities == [0.9, 0.1]
-
-
-class TestGetSingletonLangDetect(unittest.TestCase):
-
-    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.has_name', return_value=False)
-    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.set_resource')
-    def test_get_singleton_lang_detect_new_instance(self, mock_set_resource, mock_has_name):
-        lang_id_instance = MagicMock()
-        with patch('llm_web_kit.model.lang_id.LanguageIdentification', return_value=lang_id_instance):
-            result = get_singleton_lang_detect('model_path')
-            mock_set_resource.assert_called_once_with('lang_detect_model_path', lang_id_instance)
-            self.assertEqual(result, lang_id_instance)
-
-    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.has_name', return_value=True)
-    @patch('llm_web_kit.model.lang_id.singleton_resource_manager.get_resource', return_value='mock_lang_id_instance')
-    def test_get_singleton_lang_detect_existing_instance(self, mock_get_resource, mock_has_name):
-        result = get_singleton_lang_detect('model_path')
-        mock_get_resource.assert_called_once_with('lang_detect_model_path')
-        self.assertEqual(result, 'mock_lang_id_instance')
 
 
 class TestDecideLanguageByProbV176(unittest.TestCase):
@@ -132,7 +117,7 @@ def test_update_language_by_str():
             'language': 'en',
             'language_details': 'en_v218'
         }
-        assert result == expected_result, f"Expected {expected_result}, but got {result}"
+        assert result == expected_result, f'Expected {expected_result}, but got {result}'
         print('Test passed!')
 
 
@@ -157,3 +142,7 @@ class TestDecideLangByStrV218(unittest.TestCase):
         content_str = 'Este es un texto en español.'
         result = decide_lang_by_str_v218(content_str, 'custom_model_path')
         self.assertEqual(result, 'es')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
修改默认下载模型,目前默认使用lid218模型,通过映射表保证输出与lid176一致,新增decide_lang_by_str_v218,update_language_by_str_v218用于输出iso639-3_书写格式的详细信息,修改完善注释