### PR TITLE
[CI]: python3.11 and 3.12 run when requirements modify

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,5 @@
 coverage:
   status:
-    project: off  # 关闭项目整体覆盖率检查
-
     patch:  # 只检查变更部分的覆盖率
       default:
         target: 85%  # 变更代码的覆盖率目标

--- a/.github/workflows/pr_stage_test.yml
+++ b/.github/workflows/pr_stage_test.yml
@@ -45,7 +45,7 @@ jobs:
           pip install -r requirements/runtime.txt
           pip install -r requirements/dev.txt
       - name: Run tests and collect coverage
-        run: pytest --cov --cov-report=xml ./tests/llm_web_kit
+        run: pytest --cov --cov-report=xml -n auto ./tests/llm_web_kit
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -55,8 +55,7 @@ jobs:
   pr_ut_test_extra:
     runs-on: ubuntu-latest
     # 只在 requirements 目录有修改时运行此 job
-    if: contains(github.event.pull_request.files.*.path, 'requirements/')
-
+    if: contains(github.event.pull_request.files.*.path, 'requirements/') || contains(github.event.pull_request.files.*.path, 'setup.py')
     strategy:
       matrix:
         python-version: [3.11.11, 3.12.8]
@@ -76,7 +75,7 @@ jobs:
           pip install -r requirements/runtime.txt
           pip install -r requirements/dev.txt
       - name: Run tests and collect coverage
-        run: pytest --cov --cov-report=xml ./tests/llm_web_kit
+        run: pytest --cov --cov-report=xml -n auto ./tests/llm_web_kit
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/pr_stage_test.yml
+++ b/.github/workflows/pr_stage_test.yml
@@ -28,7 +28,7 @@ jobs:
       PYTHONPATH: $PYTHONPATH:${{ github.workspace }}
     strategy:
       matrix:
-        python-version: [3.10.15, 3.11.11, 3.12.8]
+        python-version: [3.10.15]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pr_stage_test.yml
+++ b/.github/workflows/pr_stage_test.yml
@@ -36,10 +36,37 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      # - name: Install build dependencies
-      #   run: |
-      #     pip install maturin
-      #     pip install --prefer-binary tokenizers>=0.19.0
+      - name: Build llm_web_kit from source
+        run: |
+          pip install -e .
+          pip list | grep llm_web_kit
+      - name: Install unit tests dependencies
+        run: |
+          pip install -r requirements/runtime.txt
+          pip install -r requirements/dev.txt
+      - name: Run tests and collect coverage
+        run: pytest --cov --cov-report=xml ./tests/llm_web_kit
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+ # 额外的 Python 版本测试，只在 requirements 目录有修改时运行
+  pr_ut_test_extra:
+    runs-on: ubuntu-latest
+    # 只在 requirements 目录有修改时运行此 job
+    if: contains(github.event.pull_request.files.*.path, 'requirements/')
+
+    strategy:
+      matrix:
+        python-version: [3.11.11, 3.12.8]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Build llm_web_kit from source
         run: |
           pip install -e .
@@ -62,7 +89,7 @@ jobs:
       PYTHONPATH: $PYTHONPATH:${{ github.workspace }}
     strategy:
       matrix:
-        python-version: [3.10.15, 3.11.11, 3.12.8]
+        python-version: [3.10.15]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,10 +97,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      # - name: Install build dependencies
-      #   run: |
-      #     pip install maturin
-      #     pip install --prefer-binary tokenizers>=0.19.0
       - name: Build llm_web_kit from source
         run: |
           pip install -e .

--- a/.github/workflows/pr_stage_test.yml
+++ b/.github/workflows/pr_stage_test.yml
@@ -45,37 +45,7 @@ jobs:
           pip install -r requirements/runtime.txt
           pip install -r requirements/dev.txt
       - name: Run tests and collect coverage
-        run: pytest --cov --cov-report=xml -n auto ./tests/llm_web_kit
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
- # 额外的 Python 版本测试，只在 requirements 目录有修改时运行
-  pr_ut_test_extra:
-    runs-on: ubuntu-latest
-    # 只在 requirements 目录有修改时运行此 job
-    if: contains(github.event.pull_request.files.*.path, 'requirements/') || contains(github.event.pull_request.files.*.path, 'setup.py')
-    strategy:
-      matrix:
-        python-version: [3.11.11, 3.12.8]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Build llm_web_kit from source
-        run: |
-          pip install -e .
-          pip list | grep llm_web_kit
-      - name: Install unit tests dependencies
-        run: |
-          pip install -r requirements/runtime.txt
-          pip install -r requirements/dev.txt
-      - name: Run tests and collect coverage
-        run: pytest --cov --cov-report=xml -n auto ./tests/llm_web_kit
+        run: pytest --cov --cov-report=xml ./tests/llm_web_kit
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/pr_ut_test_extra.yml
+++ b/.github/workflows/pr_ut_test_extra.yml
@@ -18,6 +18,9 @@ jobs:
   # 额外的 Python 版本测试，只在 requirements 目录有修改时运行
   pr_ut_test_extra:
     runs-on: ubuntu-latest
+    env:
+      LLM_WEB_KIT_CFG_PATH: ${{ github.workspace }}/bench/config/ours_config.jsonc
+      PYTHONPATH: $PYTHONPATH:${{ github.workspace }}
     strategy:
       matrix:
         python-version: [3.11.11, 3.12.8]

--- a/.github/workflows/pr_ut_test_extra.yml
+++ b/.github/workflows/pr_ut_test_extra.yml
@@ -1,0 +1,44 @@
+name: pr_stage_ut_extra
+
+on:
+  pull_request:
+    paths:
+      - 'requirements/**'
+      - 'setup.py'
+  push:
+    branches:
+      - main
+      - dev
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # 额外的 Python 版本测试，只在 requirements 目录有修改时运行
+  pr_ut_test_extra:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.11.11, 3.12.8]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build llm_web_kit from source
+        run: |
+          pip install -e .
+          pip list | grep llm_web_kit
+      - name: Install unit tests dependencies
+        run: |
+          pip install -r requirements/runtime.txt
+          pip install -r requirements/dev.txt
+      - name: Run tests and collect coverage
+        run: pytest --cov --cov-report=xml -n auto ./tests/llm_web_kit
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@ pydantic==2.10.6
 pytest==8.3.3
 # coverage tools
 pytest-cov==6.0.0
+pytest-xdist==3.6.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,4 +3,4 @@ pydantic==2.10.6
 pytest==8.3.3
 # coverage tools
 pytest-cov==6.0.0
-pytest-xdist==3.6.
+pytest-xdist==3.6.1


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

1. 讨论结果：CI没必要每次都跑3.10-3.12，只在requirements目录下有变动时候触发

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
