### PR TITLE
feat: 添加 CleanModule 文档及参数说明，支持内容质量清洗

### DIFF
--- a/docs/llm_web_kit/model/clean_module.md
+++ b/docs/llm_web_kit/model/clean_module.md
@@ -1,0 +1,73 @@
+## 作用
+
+对输入数据进行质量清洗。
+注意：需要语言模型先决定输入数据的语言，语言模型见 `docs/llm_web_kit/model/lang_id.md`。
+
+## 配置文件需要改动的部分
+
+```json
+"resources": {
+        "common":{
+            "cache_path": "~/.llm_web_kit_cache"
+        },
+        "zh_en_article":{
+            "download_path": "s3://web-parse-huawei/shared_resource/quality/zh_en/zh_en_article.zip",
+            "md5": "ebc8be83b86e0d1ee2c9b797ad8f6130",
+        },
+        "zh_en_long_article":{
+            "download_path": "s3://web-parse-huawei/shared_resource/quality/zh_en/zh_en_long_article.zip",
+            "md5": "4586a9536ee7e731dac87361755e8026",
+        },
+    },
+```
+
+## 调用方法
+
+```python
+from llm_web_kit.model.clean_module import CleanModule, ContentStyle
+from llm_web_kit.model.lang_id import update_language_by_str
+
+content_str = "Your content string here."
+# content_style = "article", "book", "paper" ...
+content_style = ContentStyle.ARTICLE
+
+# language = "en", "zh"
+# language_details = "eng_Latn", "zho_Hans"
+language, language_details = update_language_by_str(content_str)
+
+
+clean_module = CleanModule(prod = True)
+result = clean_module.process(
+             content_str=content_str,
+             language=language,
+             language_details=language_details,
+             content_style=content_style,
+         )
+
+assert isinstance(result, dict)
+
+print(result["clean_remained"]) # True or False
+print(result["clean_infos"]) # An info dict like {'quality_prob': 0.0}
+
+```
+
+## 参数说明
+
+class CleanModule
+
+- prod: bool
+  - 是否使用生产环境的模型。默认为True。
+
+def process
+
+- content_str: str
+  - 输入的文本内容。
+- language: str
+  - 输入的文本内容的语言。
+  - 例如：en, zh
+- language_details: str
+  - 输入的文本内容的语言细节。
+  - 例如：eng_Latn, zho_Hans
+- content_style: ContentStyle
+  - 输入的文本内容的风格。
+  - ContentStyle.ARTICLE, ContentStyle.BOOK, ContentStyle.PAPER

--- a/llm_web_kit/model/clean_module.py
+++ b/llm_web_kit/model/clean_module.py
@@ -1,6 +1,14 @@
+from enum import Enum
 from typing import Any, Type
 
 from llm_web_kit.model.quality_model import QualityFilter
+
+
+# 定义枚举类型 ContentStyle
+class ContentStyle(Enum):
+    ARTICLE = 'article'
+    BOOK = 'book'
+    PAPER = 'paper'
 
 
 def check_type(arg_name: str, arg_value: Any, arg_type: Type):
@@ -23,7 +31,7 @@ class CleanModuleDataPack:
         content_str: str,
         language: str,
         language_details: str,
-        content_style: str,
+        content_style: ContentStyle,
     ):
 
         # the content of the dataset
@@ -39,8 +47,9 @@ class CleanModuleDataPack:
         self.language_details = language_details
 
         # the content style of the content
-        check_type('content_style', content_style, str)
-        self.content_style = content_style
+        check_type('content_style', content_style, ContentStyle)
+
+        self.content_style = content_style.value
 
         # the flag of the processed data should be remained or not
         self.clean_remained = True
@@ -66,7 +75,7 @@ class CleanModuleDataPack:
 class CleanModule:
     def __init__(self, prod: bool):
         # when in production mode
-        # the process will return immediately when the data is not safe
+        # the process will return immediately when the data is not clean
         self.prod = prod
         self.quality_filter = QualityFilter()
 

--- a/llm_web_kit/model/quality_model.py
+++ b/llm_web_kit/model/quality_model.py
@@ -95,7 +95,7 @@ class QualityModel:
         feature_df = pd.json_normalize(features_dict)
         pred = self.quality_model.predict(feature_df)[0]
 
-        return pred
+        return float(pred)
 
     def predict_with_content(self, content: str, content_style: str = None) -> float:
         # 停用词相关

--- a/tests/llm_web_kit/model/test_clean_module.py
+++ b/tests/llm_web_kit/model/test_clean_module.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 # 需要根据实际模块路径调整
 from llm_web_kit.model.clean_module import (CleanModule, CleanModuleDataPack,
-                                            check_type)
+                                            ContentStyle, check_type)
 from llm_web_kit.model.quality_model import QualityFilter
 
 
@@ -34,7 +34,7 @@ class TestCleanModuleDataPack(TestCase):
             'content_str': 'test',
             'language': 'en',
             'language_details': 'details',
-            'content_style': 'article',
+            'content_style': ContentStyle.ARTICLE,
         }
 
         # 测试所有参数的正确类型
@@ -52,7 +52,7 @@ class TestCleanModuleDataPack(TestCase):
 
     def test_set_process_result(self):
         """测试设置处理结果的功能."""
-        data_pack = CleanModuleDataPack('test', 'en', 'details', 'article')
+        data_pack = CleanModuleDataPack('test', 'en', 'details', ContentStyle.ARTICLE)
 
         # 测试正确类型
         data_pack.set_process_result(False, {'key': 'value'})
@@ -68,7 +68,7 @@ class TestCleanModuleDataPack(TestCase):
 
     def test_get_output(self):
         """测试输出字典的生成."""
-        data_pack = CleanModuleDataPack('test', 'en', 'details', 'article')
+        data_pack = CleanModuleDataPack('test', 'en', 'details', ContentStyle.ARTICLE)
         data_pack.set_process_result(False, {'info': 'test'})
 
         expected_output = {'clean_remained': False, 'clean_infos': {'info': 'test'}}
@@ -84,13 +84,13 @@ class TestCleanModule(TestCase):
 
         # 初始化测试对象
         clean_module = CleanModule(prod=True)
-        data_pack = CleanModuleDataPack('test', 'en', 'details', 'article')
+        data_pack = CleanModuleDataPack('test', 'en', 'details', ContentStyle.ARTICLE)
 
         # 执行核心处理
         result = clean_module.process_core(data_pack)
 
         # 验证过滤方法被正确调用
-        mock_filter.assert_called_once_with('test', 'en', 'details', 'article')
+        mock_filter.assert_called_once_with('test', 'en', 'details', ContentStyle.ARTICLE.value)
         # 验证处理结果设置正确
         self.assertFalse(result.clean_remained)
         self.assertEqual(result.clean_infos, {'reason': 'test'})
@@ -105,7 +105,7 @@ class TestCleanModule(TestCase):
             content_str='content',
             language='en',
             language_details='details',
-            content_style='article',
+            content_style=ContentStyle.ARTICLE,
         )
 
         expected_result = {'clean_remained': True, 'clean_infos': {'quality': 0.95}}


### PR DESCRIPTION
## 作用

对输入数据进行质量清洗。
注意：需要语言模型先决定输入数据的语言，语言模型见 `docs/llm_web_kit/model/lang_id.md`。

## 配置文件需要改动的部分

```json
"resources": {
        "common":{
            "cache_path": "~/.llm_web_kit_cache"
        },
        "zh_en_article":{
            "download_path": "s3://web-parse-huawei/shared_resource/quality/zh_en/zh_en_article.zip",
            "md5": "ebc8be83b86e0d1ee2c9b797ad8f6130",
        },
        "zh_en_long_article":{
            "download_path": "s3://web-parse-huawei/shared_resource/quality/zh_en/zh_en_long_article.zip",
            "md5": "4586a9536ee7e731dac87361755e8026",
        },
    },
```

## 调用方法

```python
from llm_web_kit.model.clean_module import CleanModule, ContentStyle
from llm_web_kit.model.lang_id import update_language_by_str

content_str = "Your content string here."
# content_style = "article", "book", "paper" ...
content_style = ContentStyle.ARTICLE

# language = "en", "zh"
# language_details = "eng_Latn", "zho_Hans"
language, language_details = update_language_by_str(content_str)


clean_module = CleanModule(prod = True)
result = clean_module.process(
             content_str=content_str,
             language=language,
             language_details=language_details,
             content_style=content_style,
         )

assert isinstance(result, dict)

print(result["clean_remained"]) # True or False
print(result["clean_infos"]) # An info dict like {'quality_prob': 0.0}

```

## 参数说明

class CleanModule

- prod: bool
  - 是否使用生产环境的模型。默认为True。

def process

- content_str: str
  - 输入的文本内容。
- language: str
  - 输入的文本内容的语言。
  - 例如：en, zh
- language_details: str
  - 输入的文本内容的语言细节。
  - 例如：eng_Latn, zho_Hans
- content_style: ContentStyle
  - 输入的文本内容的风格。
  - ContentStyle.ARTICLE, ContentStyle.BOOK, ContentStyle.PAPER
