### PR TITLE
mock CACHE_TMP_DIR in test cases

### DIFF
--- a/tests/llm_web_kit/model/resource_utils/test_download_assets.py
+++ b/tests/llm_web_kit/model/resource_utils/test_download_assets.py
@@ -65,8 +65,10 @@ class TestConnections:
 
 class TestDownloadCoreFunctionality(unittest.TestCase):
 
+    @patch('llm_web_kit.model.resource_utils.download_assets.CACHE_TMP_DIR')
     @patch('llm_web_kit.model.resource_utils.download_assets.S3Connection')
-    def test_successful_download(self, mock_conn):
+    def test_successful_download(self, mock_conn, mock_cache_tmp_dir):
+        mock_cache_tmp_dir.return_value = '/tmp'
         # Mock connection
         download_data = b'data'
         mock_instance = MagicMock()
@@ -81,8 +83,10 @@ class TestDownloadCoreFunctionality(unittest.TestCase):
             assert result == target
             assert os.path.exists(target)
 
+    @patch('llm_web_kit.model.resource_utils.download_assets.CACHE_TMP_DIR')
     @patch('llm_web_kit.model.resource_utils.download_assets.HttpConnection')
-    def test_size_mismatch(self, mock_conn):
+    def test_size_mismatch(self, mock_conn, mock_cache_tmp_dir):
+        mock_cache_tmp_dir.return_value = '/tmp'
         download_data = b'data'
         mock_instance = MagicMock()
         mock_instance.read_stream.return_value = [download_data]
@@ -92,6 +96,7 @@ class TestDownloadCoreFunctionality(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             target = os.path.join(tmpdir, 'target.file')
+            print(target)
             with self.assertRaises(ModelResourceException):
                 download_auto_file_core('http://example.com', target)
 

--- a/tests/llm_web_kit/model/resource_utils/test_unzip_ext.py
+++ b/tests/llm_web_kit/model/resource_utils/test_unzip_ext.py
@@ -106,6 +106,7 @@ class TestUnzipLocalFileCore(TestCase):
             unzip_local_file_core(self.zip_path, self.target_dir)
         self.assertIn('already exists', str(cm.exception))
 
+    @patch('llm_web_kit.model.resource_utils.unzip_ext.CACHE_TMP_DIR', '/tmp')
     def test_successful_extraction(self):
         with zipfile.ZipFile(self.zip_path, 'w') as zipf:
             zipf.writestr('file.txt', 'content')
@@ -114,6 +115,7 @@ class TestUnzipLocalFileCore(TestCase):
         self.assertEqual(result, self.target_dir)
         self.assertTrue(os.path.exists(os.path.join(self.target_dir, 'file.txt')))
 
+    @patch('llm_web_kit.model.resource_utils.unzip_ext.CACHE_TMP_DIR', '/tmp')
     def test_password_protected_extraction(self):
         password = 'secret'
         with zipfile.ZipFile(self.zip_path, 'w') as zipf:
@@ -136,6 +138,7 @@ class TestUnzipLocalFile(TestCase):
     def tearDown(self):
         self.temp_dir.cleanup()
 
+    @patch('llm_web_kit.model.resource_utils.unzip_ext.CACHE_TMP_DIR', '/tmp')
     @patch(
         'llm_web_kit.model.resource_utils.unzip_ext.process_and_verify_file_with_lock'
     )


### PR DESCRIPTION
mock CACHE_TMP_DIR to “/tmp”  to prevent permission denied