### PR TITLE
修复“从网页提取出来的表格包含多余的空格”的问题

### DIFF
--- a/llm_web_kit/main_html_parser/simplify_html/simplify_html.py
+++ b/llm_web_kit/main_html_parser/simplify_html/simplify_html.py
@@ -887,6 +887,6 @@ def simplify_html(html_str) -> etree.Element:
     simplified_html = process_paragraphs(paragraphs, original_uid_map)
 
     remove_all_uids(original_dom)
-    original_html = etree.tostring(original_dom, pretty_print=True, method='html', encoding='unicode')
+    original_html = etree.tostring(original_dom, pretty_print=False, method='html', encoding='unicode')
 
     return simplified_html, original_html


### PR DESCRIPTION
在simplify的最后一行，etree.tostring函数中的pretty_print原为True，会使得original_html中包含一些额外的换行和缩进，如果网页中包含表格等内容，提取之后表格也会包含一些额外的空格，为了跟直接从labeled_html提取的ground truth对齐，故将pretty_print改为False，这样就不会多出来一些空格。